### PR TITLE
Bug fix: Check failed if the source file is empty 

### DIFF
--- a/burocrata/cli.py
+++ b/burocrata/cli.py
@@ -88,9 +88,12 @@ def main(extension, check, verbose, directory):
                     continue
                 amount += 1
                 with open(path) as file:
-                    for notice_line, file_line in zip(notice, file):
-                        # Use [:-1] to strip the newline from the end
-                        if notice_line != file_line[:-1]:
+                    source_code = path.read_text().split("\n")
+                if source_code:
+                    missing_notice.append(path)
+                else:
+                    for notice_line, file_line in zip(notice, source_code):
+                        if notice_line != file_line:
                             missing_notice.append(path)
                             break
         reporter.echo(

--- a/burocrata/cli.py
+++ b/burocrata/cli.py
@@ -87,9 +87,8 @@ def main(extension, check, verbose, directory):
                 if gitignore.match_file(path):
                     continue
                 amount += 1
-                with open(path) as file:
-                    source_code = path.read_text().split("\n")
-                if source_code:
+                source_code = path.read_text().split("\n")
+                if not source_code:
                     missing_notice.append(path)
                 else:
                     for notice_line, file_line in zip(notice, source_code):


### PR DESCRIPTION
Since we compared line by line the source and notice, the check failed
if the source file was empty (no comparison was made). Fix this by
loading the entire source file and checking if it's empty.